### PR TITLE
Update version requirements and setuptools testing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,13 +20,15 @@ from setuptools import find_packages, setup
 setup(
     name="adderall",
     version="2.0.0",
-    install_requires=['hy>=0.10', 'monaxhyd>=0.1.0'],
+    install_requires=['hy>=0.15', 'monaxhyd>=0.2.1'],
     packages=find_packages(exclude=['tests', 'tests.extra', 'tests.schemer']),
     package_data={
         'adderall': ['*.hy'],
         'adderall.extra': ['*.hy'],
         'adderall.extra.cheezburger': ['*.hy'],
     },
+    test_suite='nose.collector',
+    tests_require=['nose'],
     author="Gergely Nagy",
     author_email="algernon@madhouse-project.org",
     long_description="""a miniKanren implementation in Hy.""",


### PR DESCRIPTION
Unfortunately, commands like `nosetests` and `python setup.py test` won't work &mdash; at least without cached bytecode present for this project and its dependencies &mdash; until Hy's import mechanics are fixed.  

Testing with hylang/hy#1672 confirms that, under these changes, both test commands should successfully complete all tests from within a fresh virtualenv (on the first attempt).

Also, after this is merged, we should add a tag to match the version in `setup.py` (i.e. `2.0.0`).  Actually, it might be nice to adopt some form of Git tag versioning, like Hy itself does (i.e. [`get_version.py`](https://github.com/hylang/hy/blob/master/get_version.py) and in [`setup.py`](https://github.com/hylang/hy/blob/master/setup.py#L42)).