### PR TITLE
Fix package module loading in Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,114 @@
-/build/
-/dist/
-/.noseids
-*.egg-info/
-*.pyc
+# Most of these entries are from https://github.com/github/gitignore/raw/master/Python.gitignore
 *~
+/.noseids
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ python:
   - "pypy3.5"
 install: pip install -r requirements.txt
 script:
-  - nosetests
-  - python tests/bench.py
+  - nosetests tests
+  - nosetests -qs -m benchmark tests/bench.py

--- a/adderall/__init__.py
+++ b/adderall/__init__.py
@@ -1,0 +1,2 @@
+# Make Hy sub-modules discoverable via Python
+import hy

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -15,22 +15,29 @@
 ## You should have received a copy of the GNU Lesser General Public
 ## License along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import timeit
 import hy
 import sys
+import timeit
+from nose.tools import nottest
 
-SETUP_FORMAT="""import hy
+
+SETUP_FORMAT = """import hy
 from {0} import {1}"""
 
-def benchmark(module, function, times = 10):
-    print ("{0}/{1} * {2}:".format(module, function, times)),
+
+@nottest
+def benchmark(module, function, times=10):
+    print("{0}/{1} * {2}:".format(module, function, times)),
     sys.__stdout__.flush()
     result = timeit.timeit("{0}()".format(function),
-                           setup = SETUP_FORMAT.format(module, function),
-                           number = times)
-    print ("{0:.5f}s ({1:.5f}s average)".format(result, result / times))
+                           setup=SETUP_FORMAT.format(module, function),
+                           number=times)
+    print("{0:.5f}s ({1:.5f}s average)".format(result, result / times))
 
 
-if __name__ == '__main__':
+def test_zebra_benchmark():
     benchmark("tests.extra.zebra_bench", "zebra_benchmark")
+
+
+def test_cheetah_benchmark():
     benchmark("tests.extra.cheetah_bench", "cheetah_benchmark", 100)


### PR DESCRIPTION
Package modules couldn't be imported in Python (e.g. `import adderall.dsl`) because the Hy importer wasn't being loaded.  This commit fixes that.