### PR TITLE
Fix results of __iter__ for ConsPair

### DIFF
--- a/adderall/dsl.hy
+++ b/adderall/dsl.hy
@@ -507,7 +507,7 @@ See `≡`/`==`."
   (≡ u v))
 
 (defn-alias [pairᵒ pairo] [l]
-  "A goal that assigns the property of being a pair (i.e.  made from a `cons`
+  "A goal that assigns the property of being a pair (i.e. made from a `cons`
 between two elements).
 
 Examples

--- a/adderall/internal.hy
+++ b/adderall/internal.hy
@@ -38,9 +38,37 @@
        ret))
 
 (defclass ConsPair [Iterable]
-  (defn --init-- [self car cdr]
-    (setv self.car car)
-    (setv self.cdr cdr))
+  "Construct a cons list.
+
+A Python `list` is returned when the cdr is a `list` or `None`; otherwise, a
+`ConsPair` is returned.
+
+The arguments to `ConsPair` can be a car & cdr pair, or a sequence of objects to
+be nested in `cons`es, e.g.
+
+    (ConsPair car-1 car-2 car-3 cdr) == (ConsPair car-1 (cons car-2 (cons car-3 cdr)))
+"
+  (defn --new-- [cls &rest parts]
+    (if (> (len parts) 2)
+        (reduce (fn [x y] (ConsPair y x))
+                (reversed parts))
+        ;; Handle basic car, cdr case.
+        (do (setv car-part (-none-to-empty-or-list
+                             (first parts)))
+            (setv cdr-part (-none-to-empty-or-list
+                             (if (and (coll? parts)
+                                      (> (len parts) 1))
+                                 (last parts)
+                                 None)))
+            (if (list? cdr-part)
+                ;; Try to preserve the exact type of list
+                ;; (e.g. in case it's actually a HyList).
+                (+ ((type cdr-part) [car-part]) cdr-part)
+                (do
+                  (setv instance (.--new-- (super ConsPair cls) cls))
+                  (setv instance.car car-part)
+                  (setv instance.cdr cdr-part)
+                  instance)))))
   (defn --hash-- [self]
     (hash [self.car, self.cdr]))
   (defn --eq-- [self other]
@@ -63,33 +91,8 @@
          (list x)]
         [True x]))
 
-(defn cons [&rest parts]
-  "Construct a cons list.
-
-A list is returned when the cdr is a list or None; otherwise, a ConsPair is
-returned.
-
-The PARTS argument can be a car, cdr pair, or a list of cons arguments to be nested, i.e.
-
-    (cons car-1 car-2 car-3 cdr) == (cons car-1 (cons car-2 (cons car-3 cdr)))
-"
-  (if (> (len parts) 2)
-      (reduce (fn [x y] (cons y x))
-              (reversed parts))
-      ;; Handle basic car, cdr case.
-      (let [car-part (-none-to-empty-or-list
-                       (first parts))
-            cdr-part (-none-to-empty-or-list
-                       (if (and (coll? parts)
-                                (> (len parts) 1))
-                           (last parts)
-                           None))]
-           (cond [(list? cdr-part)
-                  ;; Try to preserve the exact type of list
-                  ;; (e.g. in case it's actually a HyList).
-                  (+ ((type cdr-part) [car-part])
-                     cdr-part)]
-                 [True (ConsPair car-part cdr-part)]))))
+;; A synonym for ConsPair
+(setv cons ConsPair)
 
 (defn car [z]
   (or (getattr z "car" None)
@@ -100,8 +103,6 @@ The PARTS argument can be a car, cdr pair, or a list of cons arguments to be nes
       ;; (e.g. in case it's actually a HyList).
       ((type z) (list (rest z)))))
 
-(defn neseq? [c]
-  (and (seq? c) (not (empty? c))))
 (defn lvar? [x] (instance? LVar x))
 (defn tuple? [x] (instance? tuple x))
 (defn list? [x] (instance? list x))
@@ -109,6 +110,8 @@ The PARTS argument can be a car, cdr pair, or a list of cons arguments to be nes
                         (tuple? x))
                    (instance? list x)
                    (instance? set x)))
+(defn neseq? [c]
+  (and (seq? c) (not (empty? c))))
 (defn cons? [a]
   (if (or (and (list? a) (not (empty? a)))
           (instance? ConsPair a))

--- a/tests/adderall_test.hy
+++ b/tests/adderall_test.hy
@@ -14,7 +14,8 @@
 ;; You should have received a copy of the GNU Lesser General Public
 ;; License along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-(import [adderall.dsl [*]]
+(import [nose.tools [assert-equal assert-not-equal]]
+        [adderall.dsl [*]]
         [adderall.internal [*]])
 
 (require [adderall.dsl [*]])
@@ -22,178 +23,182 @@
 (require [tests.utils [*]])
 (require [hy.contrib.walk [let]])
 
+(defn assert-all-equal [&rest tests]
+  (reduce (fn [x y] (assert-equal x y) y)
+          tests)
+  None)
 
 (defn test-cons []
-  (assert (= (cons 'a None)
-             (cons 'a [])
-             (cons 'a (,))
-             (cons 'a '())
-             ['a]
-             '(a)))
-  (assert (= (cons None 'a)
-             (cons [] 'a)
-             (cons (,) 'a)
-             (cons '() 'a)))
-  (assert (not (= (cons 'a None)
-                  (, 'a))))
-  (assert (= (cons 'a None)
-             (list (, 'a))))
+  (assert-all-equal (cons 'a None)
+                    (cons 'a [])
+                    (cons 'a (,))
+                    (cons 'a '())
+                    ['a]
+                    '(a))
+  (assert-all-equal (cons None 'a)
+                    (cons [] 'a)
+                    (cons (,) 'a)
+                    (cons '() 'a))
+  (assert-not-equal (cons 'a None)
+                    (, 'a))
+  (assert-equal (cons 'a None)
+                (list (, 'a)))
 
-  (assert (= (cons 'a '(b c))
-             (cons 'a ['b 'c])
-             (cons 'a (, 'b 'c))
-             '(a b c)
-             ['a 'b 'c]))
-  (assert (not (= (cons 'a (, 'b 'c))
-                  (, 'a))))
-  (assert (= (cons 'a None)
-             (list (, 'a))))
+  (assert-all-equal (cons 'a '(b c))
+                    (cons 'a ['b 'c])
+                    (cons 'a (, 'b 'c))
+                    '(a b c)
+                    ['a 'b 'c])
+  (assert-not-equal (cons 'a (, 'b 'c))
+                    (, 'a))
+  (assert-all-equal (cons 'a None)
+                    (list (, 'a)))
 
-  (assert (= (cons '(a b) 'c)
-             (cons ['a 'b] 'c)
-             (cons (, 'a 'b) 'c)))
+  (assert-all-equal (cons '(a b) 'c)
+                    (cons ['a 'b] 'c)
+                    (cons (, 'a 'b) 'c))
 
-  (assert (= (cons '(a b) '(c d))
-             (cons '(a b) ['c 'd])
-             (cons '(a b) (, 'c 'd))
-             [['a 'b] 'c 'd]
-             '((a b) c d)))
-  (assert (not (= (cons 'a (, 'b 'c))
-                  (, 'a 'b 'c))))
-  (assert (= (cons 'a (, 'b 'c))
-             (list (, 'a 'b 'c))))
-  (assert (= (cons '(a b) 'c)
-             (cons ['a 'b] 'c)
-             (cons (, 'a 'b) 'c)))
-  (assert (= (cons '(a b) '(c))
-             (cons ['a 'b] ['c])
-             (cons (, 'a 'b) (, 'c))
-             [['a 'b] 'c]
-             '((a b) c)))
-  (assert (= (car (cons 'a 'b))
-             'a))
-  (assert (= (car (cons '(a b) 'a))
-             (car (cons ['a 'b] 'a))
-             (car (cons (, 'a 'b) 'a))
-             ['a 'b]
-             '(a b)))
-  (assert (not (= (car (cons (, 'a 'b) 'a))
-                  (, 'a 'b))))
-  (assert (= (cdr (cons 'a 'b))
-             'b))
-  (assert (= (cdr (cons 'a None))
-             (cdr (cons '(a) None))
-             (cdr (cons 'a '()))
-             (cdr (cons 'a (,)))
-             (cdr (cons 'a []))
-             []))
-  (assert (= (cdr (cons 'a '(b)))
-             (cdr (cons '(a) '(b)))
-             (cdr (cons 'a ['b]))
-             (cdr (cons 'a (, 'b)))
-             ['b]
-             '(b)))
-  (assert (not (= (cdr (cons 'a (, 'b)))
-                  (, 'b)))))
+  (assert-all-equal (cons '(a b) '(c d))
+                    (cons '(a b) ['c 'd])
+                    (cons '(a b) (, 'c 'd))
+                    [['a 'b] 'c 'd]
+                    '((a b) c d))
+  (assert-not-equal (cons 'a (, 'b 'c))
+                    (, 'a 'b 'c))
+  (assert-all-equal (cons 'a (, 'b 'c))
+                    (list (, 'a 'b 'c)))
+  (assert-all-equal (cons '(a b) 'c)
+                    (cons ['a 'b] 'c)
+                    (cons (, 'a 'b) 'c))
+  (assert-all-equal (cons '(a b) '(c))
+                    (cons ['a 'b] ['c])
+                    (cons (, 'a 'b) (, 'c))
+                    [['a 'b] 'c]
+                    '((a b) c))
+  (assert-equal (car (cons 'a 'b))
+                'a)
+  (assert-all-equal (car (cons '(a b) 'a))
+                    (car (cons ['a 'b] 'a))
+                    (car (cons (, 'a 'b) 'a))
+                    ['a 'b]
+                    '(a b))
+  (assert-not-equal (car (cons (, 'a 'b) 'a))
+                    (, 'a 'b))
+  (assert-equal (cdr (cons 'a 'b))
+                'b)
+  (assert-all-equal (cdr (cons 'a None))
+                    (cdr (cons '(a) None))
+                    (cdr (cons 'a '()))
+                    (cdr (cons 'a (,)))
+                    (cdr (cons 'a []))
+                    [])
+  (assert-all-equal (cdr (cons 'a '(b)))
+                    (cdr (cons '(a) '(b)))
+                    (cdr (cons 'a ['b]))
+                    (cdr (cons 'a (, 'b)))
+                    ['b]
+                    '(b))
+  (assert-not-equal (cdr (cons 'a (, 'b)))
+                    (, 'b)))
 
 (defn test-fail-and-succeed []
-  (assert (= (run* [q] fail) []))
-  (assert (= (run* [q] succeed) [#U 0])))
+  (assert-equal (run* [q] fail) [])
+  (assert-equal (run* [q] succeed) [#U 0]))
 
 (defn test-s#-and-u# []
-  (assert (= (run* [q] fail) []))
-  (assert (= (run* [q] succeed) [#U 0])))
+  (assert-equal (run* [q] fail) [])
+  (assert-equal (run* [q] succeed) [#U 0]))
 
 (defn test-fresh []
-  (assert (= (run* [q] (fresh [x])) [#U 0])))
+  (assert-equal (run* [q] (fresh [x])) [#U 0]))
 
 (defn test-consᵒ []
-  (assert (= (run* [q] (consᵒ 1 [2 3] [1 2 3]))
-             [#U 0]))
-  (assert (= (run* [q] (consᵒ q [2 3] [1 2 3]))
-             [1]))
-  (assert (= (run* [q] (consᵒ q 2 (cons 1 2)))
-             [1]))
-  (assert (= (run* [q] (consᵒ q 2 '(1 2)))
-             []))
-  (assert (= (run* [q] (consᵒ 1 q [1 2 3]))
-             [[2 3]]))
-  (assert (= (run* [q] (consᵒ 1 [2 3] q))
-             [(cons 1 [2 3])]
-             [[1 2 3]]))
-  (assert (= (run* [q] (consᵒ q '(b) '(a b)))
-             ['a]))
-  (assert (= (run* [q] (consᵒ 1 [q 3] [1 2 3]))
-             [2]))
-  (assert (= (run* [q] (consᵒ 1 [2 q] [1 2 3]))
-             [3]))
-  (assert (= (run* [q] (consᵒ 1 [2 3] [q 2 3]))
-             [1]))
-  (assert (= (run* [q] (consᵒ 1 [2 3] [1 q 3]))
-             [2]))
-  (assert (= (run* [q] (consᵒ 1 [2 3] [1 2 q]))
-             [3]))
-  (assert (= (run* [q] (consᵒ 1 2 q))
-             [(cons 1 2)])))
+  (assert-equal (run* [q] (consᵒ 1 [2 3] [1 2 3]))
+                [#U 0])
+  (assert-equal (run* [q] (consᵒ q [2 3] [1 2 3]))
+                [1])
+  (assert-equal (run* [q] (consᵒ q 2 (cons 1 2)))
+                [1])
+  (assert-equal (run* [q] (consᵒ q 2 '(1 2)))
+                [])
+  (assert-equal (run* [q] (consᵒ 1 q [1 2 3]))
+                [[2 3]])
+  (assert-equal (run* [q] (consᵒ 1 [2 3] q))
+                [(cons 1 [2 3])]
+                [[1 2 3]])
+  (assert-equal (run* [q] (consᵒ q '(b) '(a b)))
+                ['a])
+  (assert-equal (run* [q] (consᵒ 1 [q 3] [1 2 3]))
+                [2])
+  (assert-equal (run* [q] (consᵒ 1 [2 q] [1 2 3]))
+                [3])
+  (assert-equal (run* [q] (consᵒ 1 [2 3] [q 2 3]))
+                [1])
+  (assert-equal (run* [q] (consᵒ 1 [2 3] [1 q 3]))
+                [2])
+  (assert-equal (run* [q] (consᵒ 1 [2 3] [1 2 q]))
+                [3])
+  (assert-equal (run* [q] (consᵒ 1 2 q))
+                [(cons 1 2)]))
 
 (defn test-project []
-  (assert (= (run* [q] (fresh [x]
-                              (≡ x 2)
-                              (≡ q (type x))))
-             [LVar]))
-  (assert (= (run* [q] (fresh [x] (≡ x 2)
-                              (project [x]
-                                       (≡ q (type x)))))
-             [(type 2)])))
+  (assert-equal (run* [q] (fresh [x]
+                                 (≡ x 2)
+                                 (≡ q (type x))))
+                [LVar])
+  (assert-equal (run* [q] (fresh [x] (≡ x 2)
+                                 (project [x]
+                                          (≡ q (type x)))))
+                [(type 2)]))
 
 (defn test-prep []
-  (assert (= (run* [q] (prep
-                        (≡ q ?x)
-                        (memberᵒ ?x [?y 4 2])
-                        (memberᵒ ?y [1 3 5])))
-             [1 3 5 4 4 4 2 2 2])))
+  (assert-equal (run* [q] (prep
+                            (≡ q ?x)
+                            (memberᵒ ?x [?y 4 2])
+                            (memberᵒ ?y [1 3 5])))
+                [1 3 5 4 4 4 2 2 2]))
 
 (defn test-set-support []
-  (assert (= (run* [q]
-                   (memberᵒ q (set [1 2 3 1 2 3])))
-             [1 2 3]))
-  (assert (= (run* [q]
-                   (memberᵒ 3 (set [1 2 q q])))
-             [3])))
+  (assert-equal (run* [q]
+                      (memberᵒ q (set [1 2 3 1 2 3])))
+                [1 2 3])
+  (assert-equal (run* [q]
+                      (memberᵒ 3 (set [1 2 q q])))
+                [3]))
 
 (defn test-lazyness []
-  (assert (= (first (wrap-stdout
-                     (lazy-run* [q]
-                                (log "hello")
-                                (≡ q True))))
-             ""))
+  (assert-equal (first (wrap-stdout
+                         (lazy-run* [q]
+                                    (log "hello")
+                                    (≡ q True))))
+                "")
 
-  (assert (= (first (wrap-stdout
-                     (list (lazy-run* [q]
-                                      (log "hello")
-                                      (≡ q True)))))
-             "hello\n"))
+  (assert-equal (first (wrap-stdout
+                         (list (lazy-run* [q]
+                                          (log "hello")
+                                          (≡ q True)))))
+                "hello\n")
 
-  (assert (= (first (wrap-stdout
-                     (run* [q]
-                           (log "hello")
-                           (≡ q True))))
-             "hello\n")))
+  (assert-equal (first (wrap-stdout
+                         (run* [q]
+                               (log "hello")
+                               (≡ q True))))
+                "hello\n"))
 
 (defn test-custom-unification []
   (defclass unifyClass [object])
   (let [l (unifyClass)]
-    (setv l.unify (fn [u v s] (, u 1 s)))
-    (assert (= (run* [q]
-                     (≡ l q))
-               [1]))
+       (setv l.unify (fn [u v s] (, u 1 s)))
+       (assert-equal (run* [q]
+                           (≡ l q))
+                     [1])
 
-    (setv l.unify None)
-    (assert (= (run* [q]
-                     (≡ l q))
-               [l]))))
+       (setv l.unify None)
+       (assert-equal (run* [q]
+                           (≡ l q))
+                     [l])))
 
 (defn test-run1 []
-  (assert (= (run¹ [q] (≡ q 1)) 1))
-  (assert (= (run¹ [q] (≡ q 1) (≡ q 2)) None))
-  (assert (= (run 1 [q] (≡ q 1)) [1])))
+  (assert-equal (run¹ [q] (≡ q 1)) 1)
+  (assert-equal (run¹ [q] (≡ q 1) (≡ q 2)) None)
+  (assert-equal (run 1 [q] (≡ q 1)) [1]))

--- a/tests/debug_test.hy
+++ b/tests/debug_test.hy
@@ -14,7 +14,8 @@
 ;; You should have received a copy of the GNU Lesser General Public
 ;; License along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-(import [adderall.dsl [*]])
+(import [nose.tools [assert-equal assert-not-equal]]
+        [adderall.dsl [*]])
 
 (require [adderall.dsl [*]])
 (require [adderall.debug [log trace-s]])
@@ -22,15 +23,15 @@
 
 
 (defn test-log []
-  (assert (= (wrap-stdout
-              (run* [q]
-                    (log "hello")
-                    (≡ q True)))
-             ["hello\n" [True]])))
+  (assert-equal (wrap-stdout
+                  (run* [q]
+                        (log "hello")
+                        (≡ q True)))
+                ["hello\n" [True]]))
 
 (defn test-trace-s []
-  (assert (= (wrap-stdout
-              (run* [q]
-                    (trace-s)
-                    (≡ q True)))
-             ["()\n" [True]])))
+  (assert-equal (wrap-stdout
+                  (run* [q]
+                        (trace-s)
+                        (≡ q True)))
+                ["()\n" [True]]))

--- a/tests/extra/cheezburger_test.hy
+++ b/tests/extra/cheezburger_test.hy
@@ -14,22 +14,23 @@
 ;; You should have received a copy of the GNU Lesser General Public
 ;; License along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-(import [adderall.dsl [*]]
+(import [nose.tools [assert-equal assert-not-equal]]
+        [adderall.dsl [*]]
         [adderall.extra.cheezburger.kitteh :as kitteh]
         [adderall.extra.cheezburger.grumpy-cat :as grumpy-cat])
 (require [adderall.dsl [*]])
 
 ;; By default, using cheezburger.kitteh, you can has anything.
 (defn test-cheezburger-kitteh []
-  (assert (= (run* [q] (kitteh.canhasᵒ 'cheezburger) (≡ q True))
-             [True]))
-  (assert (= (run* [q] (kitteh.canhasᵒ 'a-million-dollars) (≡ q True))
-             [True])))
+  (assert-equal (run* [q] (kitteh.canhasᵒ 'cheezburger) (≡ q True))
+                [True])
+  (assert-equal (run* [q] (kitteh.canhasᵒ 'a-million-dollars) (≡ q True))
+                [True]))
 
 ;; When using cheezburger.grumpy-cat, you can has cheezburger. You
 ;; want to has anything else? No.
 (defn test-cheezburger-grumpy-cat []
-  (assert (= (run* [q] (grumpy-cat.canhasᵒ 'cheezburger) (≡ q True))
-             [True]))
-  (assert (= (run* [q] (grumpy-cat.canhasᵒ 'a-million-dollars) (≡ q True))
-             [])))
+  (assert-equal (run* [q] (grumpy-cat.canhasᵒ 'cheezburger) (≡ q True))
+                [True])
+  (assert-equal (run* [q] (grumpy-cat.canhasᵒ 'a-million-dollars) (≡ q True))
+                []))

--- a/tests/extra/misc.hy
+++ b/tests/extra/misc.hy
@@ -14,7 +14,8 @@
 ;; You should have received a copy of the GNU Lesser General Public
 ;; License along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-(import [adderall.dsl [*]]
+(import [nose.tools [assert-equal assert-not-equal]]
+        [adderall.dsl [*]]
         [adderall.internal [LVar]]
         [adderall.extra.misc [*]])
 
@@ -22,17 +23,17 @@
 
 
 (defn test-typeo []
-  (assert (= (run* [q] (typeᵒ 2 3) (≡ q True))
-             [True]))
-  (assert (= (run* [q] (typeᵒ 2 "foo") (≡ q True))
-             []))
-  (assert (= (run* [q] (typeᵒ q 2))
-             [(type 2)]))
-  (assert (= (run* [q] (typeᵒ 2 q))
-             [(type 2)]))
-  (assert (= (run* [q] (fresh [x] (typeᵒ q x)))
-             [#U 0]))
-  (assert (= (run* [q] (fresh [x] (≡ x 2) (typeᵒ x q)))
-             [(type 2)]))
-  (assert (= (run* [q] (fresh [x] (≡ x 2) (typeᵒ q x)))
-             [(type 2)])))
+  (assert-equal (run* [q] (typeᵒ 2 3) (≡ q True))
+                [True])
+  (assert-equal (run* [q] (typeᵒ 2 "foo") (≡ q True))
+                [])
+  (assert-equal (run* [q] (typeᵒ q 2))
+                [(type 2)])
+  (assert-equal (run* [q] (typeᵒ 2 q))
+                [(type 2)])
+  (assert-equal (run* [q] (fresh [x] (typeᵒ q x)))
+                [#U 0])
+  (assert-equal (run* [q] (fresh [x] (≡ x 2) (typeᵒ x q)))
+                [(type 2)])
+  (assert-equal (run* [q] (fresh [x] (≡ x 2) (typeᵒ q x)))
+                [(type 2)]))

--- a/tests/extra/zebra.hy
+++ b/tests/extra/zebra.hy
@@ -14,7 +14,8 @@
 ;; You should have received a copy of the GNU Lesser General Public
 ;; License along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-(import [adderall.dsl [*]]
+(import [nose.tools [assert-equal assert-not-equal]]
+        [adderall.dsl [*]]
         [adderall.extra.zebra [*]])
 
 (require [adderall.dsl [*]])
@@ -22,11 +23,11 @@
 
 
 (defn test-zebrap []
-  (assert (= (run* [q] (zebra-tableᵖ q))
-             [[['norwegian  'kools         #U 0         'fox        'yellow]
-               ['ukrainian  'chesterfields 'tea        'horse      'blue]
-               ['englishman 'oldgods       'milk       'snails     'red]
-               ['spaniard   'lucky-strikes 'oj         'dog        'ivory]
-               ['japanese   'parliaments   'coffee     #U 1         'green]]]))
-  (assert (= (run* [water horse] (zebraᵖ water horse))
-             [['norwegian 'japanese]])))
+  (assert-equal (run* [q] (zebra-tableᵖ q))
+                [[['norwegian  'kools         #U 0         'fox        'yellow]
+                  ['ukrainian  'chesterfields 'tea        'horse      'blue]
+                  ['englishman 'oldgods       'milk       'snails     'red]
+                  ['spaniard   'lucky-strikes 'oj         'dog        'ivory]
+                  ['japanese   'parliaments   'coffee     #U 1         'green]]])
+  (assert-equal (run* [water horse] (zebraᵖ water horse))
+                [['norwegian 'japanese]]))

--- a/tests/schemer/common.hy
+++ b/tests/schemer/common.hy
@@ -14,7 +14,8 @@
 ;; You should have received a copy of the GNU Lesser General Public
 ;; License along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-(import [hy.models [HySymbol]])
+(import [nose.tools [assert-equal]]
+        [hy.models [HySymbol]])
 
 
 (defmacro/g! frame [frame-num value expr]
@@ -25,4 +26,4 @@
     `(defn ~(HySymbol name) []
        (require [hy.contrib.walk [let :as g!let]])
        (g!let [~res ~expr]
-         (assert (= ~value ~res))))))
+         (assert-equal ~value ~res)))))


### PR DESCRIPTION
The expression `(list (ConsPair 'car 'cdr))` was producing `[HySymbol("car"), "c", "d", "r"]`, i.e. mistakenly iterating over the elements in the string "cdr".  This commit fixes that and now yields `[HySymbol("car")]`.

Also, the assert statements were changed to considerably more informative ones, and there's a minor change/update to one of the docstrings.